### PR TITLE
inputProp is supported on binding update

### DIFF
--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -81,9 +81,10 @@
         //the binding's update function. keep value in sync with model
         this.update = function(element, valueAccessor) {
             var options = unwrap(valueAccessor()),
-                value = unwrap(options && options.value);
+                value = unwrap(options && options.value),
+                props = self.getPropertyNames(valueAccessor);
 
-            element.value = value;
+            element.value = value && props.input ? value[props.input] : value;
         };
 
         //if dealing with local data, the default filtering function


### PR DESCRIPTION
The missing functionality of taking a property value of an updated value object was added.

I stuck on the problem that even if I set options.inputProp to some property name, on updating of the binding the whole instance of updated data object was set to HTML Input element's value. Because of this code

```
    this.update = function (element, valueAccessor) {
        var options = unwrap(valueAccessor()),
            value = unwrap(options && options.value);

        element.value = value;
    };
```

I updated the logic and now we try to get a property value instead the whole data object value if options.inputProp is set

```
    this.update = function (element, valueAccessor) {
        var options = unwrap(valueAccessor()),
            value = unwrap(options && options.value),
            props = self.getPropertyNames(valueAccessor);

        element.value = value && props.input ? value[props.input] : value;
    };
```

Please let me know if it has any problems or I missed something important. Thanks for the great component!
