### PR TITLE
Fix issue with default text in input value

### DIFF
--- a/spec/knockout-jqAutocomplete.spec.js
+++ b/spec/knockout-jqAutocomplete.spec.js
@@ -515,6 +515,50 @@ describe("knockout-jqAutocomplete", function(){
 
             expect(input.value).toEqual("test");
         });
+        it("should set the input's value to labelProp based on valueProp", function () {
+            var items = [{ id: "1", name: "One" }],
+                value = ko.observable("1");
+
+            instance.update(input, function() {
+                return {
+                    value: value,
+                    source: items,
+                    labelProp: "name",
+                    valueProp: "id"
+                };
+            });
+
+            expect(input.value).toEqual("One");
+        });
+        it("should set the input's value to inputProp based on valueProp", function () {
+            var items = [{ id: "1", name: "One" }],
+                value = ko.observable("1");
+
+            instance.update(input, function () {
+                return {
+                    value: value,
+                    source: items,
+                    inputProp: "name",
+                    valueProp: "id"
+                };
+            });
+
+            expect(input.value).toEqual("One");
+        });
+        it("should set the input's value to valueProp based on valueProp", function () {
+            var items = [{ id: "1", name: "One" }],
+                value = ko.observable("1");
+
+            instance.update(input, function () {
+                return {
+                    value: value,
+                    source: items,
+                    valueProp: "id"
+                };
+            });
+
+            expect(input.value).toEqual("1");
+        });
     });
 
     describe("using the binding", function() {
@@ -855,6 +899,53 @@ describe("knockout-jqAutocomplete", function(){
             });
 
             expect(input.value).toEqual("testing");
+        });
+
+        it("should initially set the input's value to inputProp based on valueProp", function () {
+            var items = [{id:"1", name: "One"}],
+                value = ko.observable("1");
+
+            ko.applyBindingsToNode(input, {
+                jqAuto: {
+                    value: value,
+                    source: items,
+                    inputProp: "name",
+                    valueProp: "id"
+                }
+            });
+
+            expect(input.value).toEqual("One");
+        });
+
+        it("should initially set the input's value to labelProp based on valueProp", function () {
+            var items = [{ id: "1", name: "One" }],
+                value = ko.observable("1");
+
+            ko.applyBindingsToNode(input, {
+                jqAuto: {
+                    value: value,
+                    source: items,
+                    labelProp: "name",
+                    valueProp: "id"
+                }
+            });
+
+            expect(input.value).toEqual("One");
+        });
+
+        it("should initially set the input's value to valueProp based on valueProp", function () {
+            var items = [{ id: "1", name: "One" }],
+                value = ko.observable("1");
+
+            ko.applyBindingsToNode(input, {
+                jqAuto: {
+                    value: value,
+                    source: items,
+                    valueProp: "id"
+                }
+            });
+
+            expect(input.value).toEqual("1");
         });
 
         it("should update the input's value when the observable changes", function() {

--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -98,11 +98,15 @@
                 propNames = self.getPropertyNames(valueAccessor),
                 sources = unwrap(options.source);
 
-            if ($.isArray(sources)) {
-                value = ko.utils.arrayFirst(sources, function (opt) { return opt[propNames.value] == value; });
+            if (value && $.isArray(sources) && propNames && propNames.value) {
+                value = ko.utils.arrayFirst(sources, function (opt) { return opt[propNames.value] == value; }) || value;
             }
-
-            element.value = value[propNames.input] || value;
+            if (value && propNames && propNames.input) {
+                element.value = value[propNames.input];
+            }
+            else {
+                element.value = value;
+            }
         };
 
         //if dealing with local data, the default filtering function

--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -95,15 +95,14 @@
         this.update = function(element, valueAccessor) {
             var options = unwrap(valueAccessor()),
                 value = unwrap(options && options.value),
-                inputProp = options.inputProp || options.labelProp || options.valueProp,
-                valueProp = options.valueProp,
-                sources = ko.unwrap(options.source);
+                propNames = self.getPropertyNames(valueAccessor),
+                sources = unwrap(options.source);
 
-            if (sources.constructor === Array) {
-                value = ko.utils.arrayFirst(options.source, function (opt) { return opt[valueProp] == value; });
+            if ($.isArray(sources)) {
+                value = ko.utils.arrayFirst(sources, function (opt) { return opt[propNames.value] == value; });
             }
 
-            element.value = value[inputProp] || value;
+            element.value = value[propNames.input] || value;
         };
 
         //if dealing with local data, the default filtering function

--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -94,9 +94,16 @@
         //the binding's update function. keep value in sync with model
         this.update = function(element, valueAccessor) {
             var options = unwrap(valueAccessor()),
-                value = unwrap(options && options.value);
+                value = unwrap(options && options.value),
+                inputProp = options.inputProp || options.labelProp || options.valueProp,
+                valueProp = options.valueProp,
+                sources = ko.unwrap(options.source);
 
-            element.value = value;
+            if (sources.constructor === Array) {
+                value = ko.utils.arrayFirst(options.source, function (opt) { return opt[valueProp] == value; });
+            }
+
+            element.value = value[inputProp] || value;
         };
 
         //if dealing with local data, the default filtering function


### PR DESCRIPTION
Support correct default text when using local object arrays in the element's value.  This honors the inputProp, labelProp, and valueProp as noted in the documentation when initializing.