### PR TITLE
Update autocomplete with label option

### DIFF
--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -52,6 +52,9 @@
                     if (ko.isWriteableObservable(options.dataValue)) {
                         options.dataValue(ui.item.data);
                     }
+                    if (ko.isWriteableObservable(options.label)) {
+                        options.label(ui.item.label); 
+                    }
                 }
 
                 if (existingSelect) {
@@ -95,7 +98,8 @@
         this.update = function(element, valueAccessor) {
             var propNames, sources,
                 options = unwrap(valueAccessor()),
-                value = unwrap(options && options.value);
+                value = unwrap(options && options.value),
+                label = unwrap(options && options.label);
 
             if (!value && value !== 0) {
                 value = "";
@@ -113,7 +117,13 @@
                 ) || value;
             }
 
-            if (propNames.input && value && typeof value === "object") {
+            if (label){
+                if(typeof label === "object" && propNames.input){
+                    element.value = label[propNames.input];
+                }else{
+                    element.value = label;
+                }
+            }else if (value && typeof value === "object") {
                 element.value = value[propNames.input];
             }
             else {


### PR DESCRIPTION
The label option makes it possible to update an extra observable in your viewmodel.
This allows flattened viewmodels to update key and label of a referenced object.

e.g. I had a viewmodel with personId and personName and wanted both to update in the viewmodel. passing personId as value and personName as label solved this issue.