### PR TITLE
Missing close bracket in README in a critical place

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var viewModel = {
 ```
 
 ```html
-<input data-bind="jqAuto: { value: myValue, source: myOptions" />
+<input data-bind="jqAuto: { value: myValue, source: myOptions }" />
 ```
 
 * with a local array of objects


### PR DESCRIPTION
Minor tweak to the README file to add a missing bracket causing the basic example not to work.