### PR TITLE
Performance hit fix

### DIFF
--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -168,7 +168,7 @@
 
         //retrieve the property names to use for the label, input, and value
         this.getPropertyNames = function(valueAccessor) {
-            var options = ko.toJS(valueAccessor());
+            var options = unwrap(valueAccessor());
 
             return {
                 label: options.labelProp || options.valueProp,


### PR DESCRIPTION
ko.toJS caused performance hit since added subscription to every observable inside source collection of objects. As result, any change inside object's observables triggers update method what is a performance hit for big collection.
If ko.toJS was added with some purpose, let me know, please.