### PR TITLE
Update knockout-jqAutocomplete.spec.js

### DIFF
--- a/spec/knockout-jqAutocomplete.spec.js
+++ b/spec/knockout-jqAutocomplete.spec.js
@@ -88,7 +88,7 @@ describe("knockout-jqAutocomplete", function(){
             expect($input.autocomplete("option", "delay")).toEqual(2000);
         });
 
-        it("should override global options with local options", function() {
+        it("should override local options with global options", function() {
             instance.options = {
                 delay: 2000
             };


### PR DESCRIPTION
If the test passes with 2000, then shouldn't the test read "override local options with global"? I would think that it would override global (instance.options) with local (passed into init), but at least this fixes the test wording. Or am I not understanding which is local and which is global?