### PR TITLE
Do not return a value if the index does not exist

### DIFF
--- a/src/knockout-jqAutocomplete.js
+++ b/src/knockout-jqAutocomplete.js
@@ -110,7 +110,7 @@
                 value = ko.utils.arrayFirst(sources, function (opt) {
                         return opt[propNames.value] == value;
                     }
-                ) || value;
+                );
             }
 
             if (propNames.input && value && typeof value === "object") {


### PR DESCRIPTION
If, for some reason, a non-existent value is set for the input, it will set `undefined` as the value for the input.
This change empties the value instead.
I don't know if this causes side-effects for other use cases, but it seems to work for me.